### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/faas-perl-bibtex-2-html/function/BibStyleConverter.pm
+++ b/faas-perl-bibtex-2-html/function/BibStyleConverter.pm
@@ -186,7 +186,7 @@ sub _add_html_links {
     push @code, build_link('slides', $entry->get('slides'));
   }
   if ($entry->exists('doi')) {
-    push @code, build_link('DOI', "http://dx.doi.org/" . $entry->get('doi'));
+    push @code, build_link('DOI', "https://doi.org/" . $entry->get('doi'));
   }
   if ($entry->exists('url')) {
     push @code, build_link('http', $entry->get('url'));


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). It may be a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old `dx` subdomain is being redirected, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by updating the code that generates new DOI links.

Cheers!